### PR TITLE
Reference the livereload based on the protocol

### DIFF
--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -48,7 +48,7 @@
         </script>
 
         @if(config('app.env') == 'local')
-            <script src="http://localhost:35729/livereload.js"></script>
+            <script src="//localhost:35729/livereload.js"></script>
         @endif
     </body>
 </html>


### PR DESCRIPTION
Fixed:

Mixed Content: The page at 'https://site.app/tests-watcher/dashboard' was loaded over HTTPS, but requested an insecure script 'http://localhost:35729/livereload.js'. This request has been blocked; the content must be served over HTTPS.